### PR TITLE
Dockerfile to build httpmsgbus container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM centos:7
+
+
+# update base os and install dependencies
+RUN yum update -y && \
+    yum install -y \
+        git \
+        go \
+        pcre-devel && \
+    yum clean all
+
+
+# copy project into container
+COPY . /app/
+
+# install as unprivileged user
+RUN useradd -m httpmsgbus_user
+RUN chown -R httpmsgbus_user:httpmsgbus_user /app
+USER httpmsgbus_user
+RUN /app/install.sh
+
+
+# configure entrypoint
+WORKDIR /home/httpmsgbus_user
+EXPOSE 8000
+ENTRYPOINT [ "seiscomp3/sbin/httpmsgbus" ]


### PR DESCRIPTION
With Docker installed, a container image can be built using the following:

```
docker build -t httpmsgbus:latest .
```

And then run using the following:

```
docker run --name hmb -d -p 8000:8000 httpmsgbus:latest
```
